### PR TITLE
Set/unset environment variables locating certificates

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,0 +1,2 @@
+set "SSL_CERT_DIR=%CONDA_ENV_PATH%\ssl"
+set "SSL_CERT_FILE=%SSL_CERT_DIR%\cacert.pem"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,2 @@
+export SSL_CERT_DIR="${CONDA_ENV_PATH}/ssl"
+export SSL_CERT_FILE="${SSL_CERT_DIR}/cacert.pem"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,5 @@
+setlocal EnableDelayedExpansion
+
 :: Create the directory to hold the certificates.
 if not exist %LIBRARY_PREFIX%\ssl mkdir %LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
@@ -7,3 +9,10 @@ copy /y %SP_DIR%\certifi\cacert.pem %LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
 copy /y %LIBRARY_PREFIX%\ssl\cacert.pem %LIBRARY_PREFIX%\ssl\cert.pem
 if errorlevel 1 exit 1
+
+:: Copy the [de]activate scripts to %LIBRARY_PREFIX%\etc\conda\[de]activate.d.
+:: This will allow them to be run on environment activation.
+FOR %%F IN (activate deactivate) DO (
+    IF NOT EXIST %LIBRARY_PREFIX%\etc\conda\%%F.d MKDIR %LIBRARY_PREFIX%\etc\conda\%%F.d
+    COPY %RECIPE_DIR%/%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,3 +6,11 @@ mkdir -p "${PREFIX}/ssl"
 # Copy the certificates from certifi.
 cp -f "${SP_DIR}/certifi/cacert.pem" "${PREFIX}/ssl"
 ln -fs "${PREFIX}/ssl/cacert.pem" "${PREFIX}/ssl/cert.pem"
+
+# Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+# This will allow them to be run on environment activation.
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,2 @@
+set "SSL_CERT_DIR="
+set "SSL_CERT_FILE="

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,2 @@
+unset SSL_CERT_DIR
+unset SSL_CERT_FILE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 # This does not have a source because it pulls these from certifi at present.
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not py35]
   # As openssl includes these (dependency of Python), they will be removed afterwards.
   # This is our way of ensuring these files are kept anyways. Once conda-forge has its


### PR DESCRIPTION
This adds some [de]activate scripts to set some environment variables to point out where the certificates can be found. It is worth noting that this will influence some things like where `python` looks, but as we are setting them to the same locations they would otherwise be set to I don't think this is disruptive. This is useful in cases where one only needs this certificate bundle and needs to make sure it can be found easily. We have to use `$CONDA_ENV_PATH` to get this to work. So, would like to hear some feedback about whether that is set correctly or not.

Also, side note, this is a funny package as it can effectively be requiring itself when it builds a new version of itself. So, we are going to have to include these [de]activate scripts in the `always_include_files` section. Though it gets a bit funny as we they may or may not be present depending on whether `defaults` package for `openssl` is present or not. Don't really know what to do about this as it is a hard failure to not have the files list in `always_include_files` present.

Would really appreciate your thoughts on all of this, @msarahan.

xref: https://github.com/conda-forge/conda-forge.github.io/issues/78
xref: https://github.com/conda-forge/staged-recipes/pull/775