### PR TITLE
CONDA_ENV_PATH renamed to CONDA_PREFIX

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,2 +1,3 @@
-export SSL_CERT_DIR="${CONDA_ENV_PATH}/ssl"
+# handle conda...      >=4.1.3        <= 4.1.2
+export SSL_CERT_DIR="${CONDA_PREFIX}${CONDA_ENV_PATH}/ssl"
 export SSL_CERT_FILE="${SSL_CERT_DIR}/cacert.pem"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 # This does not have a source because it pulls these from certifi at present.
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not py35]
   # As openssl includes these (dependency of Python), they will be removed afterwards.
   # This is our way of ensuring these files are kept anyways. Once conda-forge has its


### PR DESCRIPTION
In 4.1.3 (or thereabouts) CONDA_ENV_PATH was renamed to CONDA_PREFIX:
https://github.com/conda/conda/commit/c054596ec4ee486966b474858a302d5410dd219d

This will only affect `activate.sh`, and this is the only appearance of the string in all of conda-forge.

I am assuming the two will never be set at the same time, so this approach seemed like the most straightforward, though I suppose we could do something more involved. Is this a reasonable assumption, @msarahan?