### PR TITLE
Remove [de]activate scripts

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,2 +1,0 @@
-set "SSL_CERT_DIR=%CONDA_ENV_PATH%\ssl"
-set "SSL_CERT_FILE=%SSL_CERT_DIR%\cacert.pem"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,3 +1,0 @@
-# handle conda...      >=4.1.3        <= 4.1.2
-export SSL_CERT_DIR="${CONDA_PREFIX}${CONDA_ENV_PATH}/ssl"
-export SSL_CERT_FILE="${SSL_CERT_DIR}/cacert.pem"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,3 @@
-setlocal EnableDelayedExpansion
-
 :: Create the directory to hold the certificates.
 if not exist %LIBRARY_PREFIX%\ssl mkdir %LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
@@ -9,10 +7,3 @@ copy /y %SP_DIR%\certifi\cacert.pem %LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
 copy /y %LIBRARY_PREFIX%\ssl\cacert.pem %LIBRARY_PREFIX%\ssl\cert.pem
 if errorlevel 1 exit 1
-
-:: Copy the [de]activate scripts to %LIBRARY_PREFIX%\etc\conda\[de]activate.d.
-:: This will allow them to be run on environment activation.
-FOR %%F IN (activate deactivate) DO (
-    IF NOT EXIST %LIBRARY_PREFIX%\etc\conda\%%F.d MKDIR %LIBRARY_PREFIX%\etc\conda\%%F.d
-    COPY %RECIPE_DIR%/%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
-)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,11 +6,3 @@ mkdir -p "${PREFIX}/ssl"
 # Copy the certificates from certifi.
 cp -f "${SP_DIR}/certifi/cacert.pem" "${PREFIX}/ssl"
 ln -fs "${PREFIX}/ssl/cacert.pem" "${PREFIX}/ssl/cert.pem"
-
-# Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
-# This will allow them to be run on environment activation.
-for CHANGE in "activate" "deactivate"
-do
-    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
-done

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,2 +1,0 @@
-set "SSL_CERT_DIR="
-set "SSL_CERT_FILE="

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,2 +1,0 @@
-unset SSL_CERT_DIR
-unset SSL_CERT_FILE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 # This does not have a source because it pulls these from certifi at present.
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not py35]
   # As openssl includes these (dependency of Python), they will be removed afterwards.
   # This is our way of ensuring these files are kept anyways. Once conda-forge has its
@@ -15,8 +15,10 @@ build:
   #
   # Note: The Windows copy of openssl does not include these.
   always_include_files:
-    - ssl/cert.pem      # [unix]
-    - ssl/cacert.pem    # [unix]
+    - ssl/cert.pem                # [unix]
+    - ssl/cacert.pem              # [unix]
+    - Library\\ssl\\cert.pem      # [win]
+    - Library\\ssl\\cacert.pem    # [win]
 
 requirements:
   build:


### PR DESCRIPTION
Removes the activation and deactivation scripts added in PR ( https://github.com/conda-forge/ca-certificates-feedstock/pull/2 ) and cleaned up in PR ( https://github.com/conda-forge/ca-certificates-feedstock/pull/3 ) for the moment until we can get them right.

cc @msarahan @pelson @bollwyvl 