### PR TITLE
Add core as maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,5 +48,10 @@ about:
 extra:
   recipe-maintainers:
      - jakirkham
+     - jjhelmus
      - msarahan
+     - mwcraig
+     - ocefpaf
+     - patricksnape
      - pelson
+     - scopatz


### PR DESCRIPTION
This explicitly adds all of @conda-forge/core as maintainers of `ca-certificates`. As this contains the certificates that `curl`, `openssl`, and everything else dependent on them uses, it seems paramount that all of core have access to this package should they need it. This provides that access.