### PR TITLE
Build from certifi's source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ os: osx
 osx_image: xcode6.4
 
 env:
-  matrix:
-    
-    - CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "Um1AnDJJFYCfj/VumProlaqVr9BFDEia6q6Ts4QyA3mTIeNI0urByE/yzIbDxplUzO+YQYseLLIFRKAqL2lMVxIO3h9rQzlwBL5LgbENcVM3u01Ak8gsVOAIF6aNihlglJ9vWmnEfEPi4PPr3ud+eOm3WldoSjP1CicRzeNzWv11i+ikl5Ql8e5kQ+u9v4axyf4s0odooDkcqrO9R8pYlXyUbWNylOArTKVumFFnxsIUnP2VV2nPcaKKDsLS5L5U8qnaGz1mXlMtsG1G97wB+HU3/2FzOQaBNG0QiIR0J4VuYxrG9EZz8maa8frY2BA1Ckj1riHlCZxU9xic8m6JTZeVxF+4xdk0G4QXVqJn9HK1hiaPVDzvLJJ86K3GQB5E38x6044gNCzw3Le8qGd+j42emfaqHZgCwn1O2RrB3epcsJeHVB8wIgT6buwpxsZ9PTKsOWzqDPmqI21zNtbx0s6g/cU7VB8NE5qmMhVG0wLaRYPgDer7bQ6zpnEuHwh2r2gkPPwkuoOy8Gu+/oS1LWorb3JQDl9plSlLob3FrkDEdbYeLGNN2ya+r8Q8J683tlg1hKC+2lKco73kgO+9fMuOn5XHj4SmNeRNWdNIIcsKOYiB8H6xw0eweFDrJGf3/eakuc+linBksW9WH4+SSskKOuqtX1F0ecpDtP0/UC8="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,12 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -58,9 +58,6 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 # Embarking on 1 case(s).
-    set -x
-    export CONDA_PY=35
-    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,7 @@ if not exist %LIBRARY_PREFIX%\ssl mkdir %LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
 
 :: Copy the certificates from certifi.
-copy /y %SP_DIR%\certifi\cacert.pem %LIBRARY_PREFIX%\ssl
+copy /y %SRC_DIR%\certifi\cacert.pem %LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
 copy /y %LIBRARY_PREFIX%\ssl\cacert.pem %LIBRARY_PREFIX%\ssl\cert.pem
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,5 +4,5 @@
 mkdir -p "${PREFIX}/ssl"
 
 # Copy the certificates from certifi.
-cp -f "${SP_DIR}/certifi/cacert.pem" "${PREFIX}/ssl"
+cp -f "${SRC_DIR}/certifi/cacert.pem" "${PREFIX}/ssl"
 ln -fs "${PREFIX}/ssl/cacert.pem" "${PREFIX}/ssl/cert.pem"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 81877fb7ac126e9215dfb15bfef7115fdc30e798e0013065158eed0707fd99ce
 
 build:
-  number: 0
+  number: 1
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,26 +4,13 @@ package:
   name: ca-certificates
   version: {{ version }}
 
-# This does not have a source because it pulls these from certifi at present.
+source:
+  fn: certifi-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
+  sha256: 81877fb7ac126e9215dfb15bfef7115fdc30e798e0013065158eed0707fd99ce
 
 build:
   number: 0
-  skip: true  # [not py35]
-  # As openssl includes these (dependency of Python), they will be removed afterwards.
-  # This is our way of ensuring these files are kept anyways. Once conda-forge has its
-  # own openssl, this will no longer be necessary.
-  #
-  # Note: The Windows copy of openssl does not include these.
-  always_include_files:
-    - ssl/cert.pem                # [unix]
-    - ssl/cacert.pem              # [unix]
-    - Library/ssl/cert.pem        # [win]
-    - Library/ssl/cacert.pem      # [win]
-
-requirements:
-  build:
-    - python
-    - certifi {{ version }}
 
 test:
   requires:
@@ -43,6 +30,7 @@ test:
 about:
   home: https://github.com/conda-forge/ca-certificates-feedstock
   license: ISC
+  license_file: LICENSE
   summary: Certificates for use with other packages.
 
 extra:


### PR DESCRIPTION
Closes https://github.com/conda-forge/ca-certificates-feedstock/pull/8
Fixes https://github.com/conda-forge/ca-certificates-feedstock/issues/14

Proposing we switch to building this package directly from certifi's source. That should simplify the build and update process. Also allows us to package the license file.